### PR TITLE
feat: per module requirements configs for cloud-spanner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.23
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -81,7 +81,7 @@ docker_generate_docs:
 	 	-e ENABLE_BPMETADATA=1 \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display --per-module-requirements'
 
 # Generate metadata
 .PHONY: docker_generate_metadata_w_display

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -229,18 +229,18 @@ spec:
         roles:
           - roles/owner
     services:
-      - iam.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
-      - workflows.googleapis.com
-      - cloudscheduler.googleapis.com
-      - spanner.googleapis.com
-      - pubsub.googleapis.com
-      - logging.googleapis.com
-      - storage.googleapis.com
       - appengine.googleapis.com
       - cloudkms.googleapis.com
+      - cloudresourcemanager.googleapis.com
+      - cloudscheduler.googleapis.com
+      - iam.googleapis.com
+      - logging.googleapis.com
+      - pubsub.googleapis.com
+      - serviceusage.googleapis.com
+      - spanner.googleapis.com
+      - storage-api.googleapis.com
+      - storage.googleapis.com
+      - workflows.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 6.1, < 7"

--- a/modules/schedule_spanner_backup/metadata.yaml
+++ b/modules/schedule_spanner_backup/metadata.yaml
@@ -83,18 +83,18 @@ spec:
         roles:
           - roles/owner
     services:
-      - iam.googleapis.com
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
-      - workflows.googleapis.com
-      - cloudscheduler.googleapis.com
-      - spanner.googleapis.com
-      - pubsub.googleapis.com
-      - logging.googleapis.com
-      - storage.googleapis.com
       - appengine.googleapis.com
       - cloudkms.googleapis.com
+      - cloudresourcemanager.googleapis.com
+      - cloudscheduler.googleapis.com
+      - iam.googleapis.com
+      - logging.googleapis.com
+      - pubsub.googleapis.com
+      - serviceusage.googleapis.com
+      - spanner.googleapis.com
+      - storage-api.googleapis.com
+      - storage.googleapis.com
+      - workflows.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 6.1, < 7"

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -15,9 +15,15 @@
  */
 
 locals {
-  int_required_roles = [
-    "roles/owner"
-  ]
+  per_module_roles = {
+    root = [
+      "roles/owner"
+    ]
+    schedule_spanner_backup = [
+      "roles/owner"
+    ]
+  }
+  int_required_roles = tolist(toset(flatten(values(local.per_module_roles))))
 }
 
 resource "google_service_account" "int_test" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -13,6 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+locals {
+  per_module_services = {
+    root = [
+      "iam.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "storage-api.googleapis.com",
+      "serviceusage.googleapis.com",
+      "workflows.googleapis.com",
+      "cloudscheduler.googleapis.com",
+      "spanner.googleapis.com",
+      "pubsub.googleapis.com",
+      "logging.googleapis.com",
+      "storage.googleapis.com",
+      "appengine.googleapis.com",
+      "cloudkms.googleapis.com",
+    ]
+    schedule_spanner_backup = [
+      "iam.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "storage-api.googleapis.com",
+      "serviceusage.googleapis.com",
+      "workflows.googleapis.com",
+      "cloudscheduler.googleapis.com",
+      "spanner.googleapis.com",
+      "pubsub.googleapis.com",
+      "logging.googleapis.com",
+      "storage.googleapis.com",
+      "appengine.googleapis.com",
+      "cloudkms.googleapis.com",
+    ]
+  }
+}
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
@@ -24,18 +56,5 @@ module "project" {
   folder_id         = var.folder_id
   billing_account   = var.billing_account
 
-  activate_apis = [
-    "iam.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "storage-api.googleapis.com",
-    "serviceusage.googleapis.com",
-    "workflows.googleapis.com",
-    "cloudscheduler.googleapis.com",
-    "spanner.googleapis.com",
-    "pubsub.googleapis.com",
-    "logging.googleapis.com",
-    "storage.googleapis.com",
-    "appengine.googleapis.com",
-    "cloudkms.googleapis.com",
-  ]
+  activate_apis = tolist(toset(flatten(values(local.per_module_services))))
 }


### PR DESCRIPTION
Introduced:

- per_module_roles: to config required roles to run each sub modules.
- per_module_service: to config required services to run each sub modules.

Added feature flag `--per-module-requirements` to generate_docs cmd, to align with the per module configs.