### PR TITLE
feat: adds autoscaling support + optimizes iam input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   enable_instance_nn = (
-    try(var.instance_size.num_nodes, 0) != null ?
+    try(var.instance_size.num_nodes, 0) != null && !try(var.instance_size.enable_autoscaling, false) ?
     true : false
   )
 
@@ -26,10 +26,11 @@ locals {
   }
 
   database_iam = flatten([
-    for k, v in var.database_config :
+    for database, config in var.database_config :
     [
-      for x in v.database_iam :
-      "${k}|${element(split("=>", x), 0)}|${element(split("=>", x), 1)}"
+      for role, members in config.database_iam : [
+        for member in members : "${database}|${role}|${member}"
+      ]
     ]
   ])
 
@@ -42,42 +43,71 @@ locals {
       "parent" : var.instance_name
     } if try(v.enable_backup, false)
   ]
+
+  instance_iam_processed = {
+    for el in flatten([
+      for role, members in var.instance_iam : [
+        for member in members : { key = "${role}|${member}", member = member, role = role }
+      ]
+    ]) : lookup(el, "key", "abc") => el
+  }
 }
 
 resource "google_spanner_instance" "instance_num_node" {
-  count        = local.enable_instance_nn && var.create_instance ? 1 : 0
+  count                        = local.enable_instance_nn && var.create_instance ? 1 : 0
+  project                      = var.project_id
+  config                       = var.instance_config
+  display_name                 = var.instance_display_name
+  name                         = var.instance_name
+  num_nodes                    = var.instance_size.num_nodes
+  labels                       = var.instance_labels
+  edition                      = var.edition
+  default_backup_schedule_type = var.default_backup_schedule_type
+  force_destroy                = var.force_destroy
+}
+
+
+resource "google_spanner_instance" "autoscaled" {
+  count        = try(var.instance_size.enable_autoscaling, false) && var.create_instance ? 1 : 0
   project      = var.project_id
   config       = var.instance_config
   display_name = var.instance_display_name
   name         = var.instance_name
-  num_nodes    = var.instance_size.num_nodes
   labels       = var.instance_labels
 
-  dynamic "autoscaling_config" {
-    for_each = var.enable_autoscaling ? [1] : []
-    content {
-      autoscaling_limits {
-        min_processing_units = var.min_processing_units
-        max_processing_units = var.max_processing_units
-        min_nodes            = var.min_nodes
-        max_nodes            = var.max_nodes
+  autoscaling_config {
+    dynamic "autoscaling_limits" {
+      for_each = var.autoscaling_limits != null ? [1] : []
+      content {
+        min_processing_units = var.autoscaling_limits.min_processing_units
+        max_processing_units = var.autoscaling_limits.max_processing_units
+        min_nodes            = var.autoscaling_limits.min_nodes
+        max_nodes            = var.autoscaling_limits.max_nodes
       }
-      autoscaling_targets {
-        high_priority_cpu_utilization_percent = var.high_priority_cpu_utilization_percent
-        storage_utilization_percent           = var.storage_utilization_percent
+    }
+
+    dynamic "autoscaling_targets" {
+      for_each = var.autoscaling_targets != null ? [1] : []
+      content {
+        high_priority_cpu_utilization_percent = var.autoscaling_targets.high_priority_cpu_utilization_percent
+        storage_utilization_percent           = var.autoscaling_targets.storage_utilization_percent
       }
-      asymmetric_autoscaling_options {
+    }
+    dynamic "asymmetric_autoscaling_options" {
+      for_each = var.asymmetric_autoscaling_options != null ? [1] : []
+      content {
         replica_selection {
-          location = var.replica_location
+          location = try(var.asymmetric_autoscaling_options.location, null)
         }
         overrides {
           autoscaling_limits {
-            min_nodes = var.override_min_nodes
-            max_nodes = var.override_max_nodes
+            min_nodes = try(var.asymmetric_autoscaling_options.override_autoscaling_limits.min_nodes, null)
+            max_nodes = try(var.asymmetric_autoscaling_options.override_autoscaling_limits.max_nodes, null)
           }
         }
       }
     }
+
   }
 
   edition                      = var.edition
@@ -86,7 +116,7 @@ resource "google_spanner_instance" "instance_num_node" {
 }
 
 resource "google_spanner_instance" "instance_processing_units" {
-  count            = !local.enable_instance_nn && var.create_instance ? 1 : 0
+  count            = !local.enable_instance_nn && !try(var.instance_size.enable_autoscaling, false) && var.create_instance ? 1 : 0
   project          = var.project_id
   config           = var.instance_config
   display_name     = var.instance_display_name
@@ -102,19 +132,19 @@ data "google_spanner_instance" "instance" {
 }
 
 resource "google_spanner_instance_iam_member" "instance" {
-  for_each = toset(var.instance_iam)
+  for_each = local.instance_iam_processed
   instance = (
     !var.create_instance ?
     data.google_spanner_instance.instance[0].name :
     (
       local.enable_instance_nn ?
       google_spanner_instance.instance_num_node[0].name :
-      google_spanner_instance.instance_processing_units[0].name
+      (try(var.instance_size.enable_autoscaling, false) ? google_spanner_instance.autoscaled[0].name : google_spanner_instance.instance_processing_units[0].name)
     )
   )
   project = var.project_id
-  role    = length(split("=>", each.key)) > 1 ? element(split("=>", each.key), 1) : "roles/spanner.databaseAdmin"
-  member  = length(split("=>", each.key)) > 1 ? element(split("=>", each.key), 0) : each.key
+  role    = lookup(each.value, "role", "roles/spanner.databaseAdmin")
+  member  = lookup(each.value, "member", "random")
 }
 
 resource "google_spanner_database" "database" {
@@ -125,7 +155,7 @@ resource "google_spanner_database" "database" {
     (
       local.enable_instance_nn ?
       google_spanner_instance.instance_num_node[0].name :
-      google_spanner_instance.instance_processing_units[0].name
+      (try(var.instance_size.enable_autoscaling, false) ? google_spanner_instance.autoscaled[0].name : google_spanner_instance.instance_processing_units[0].name)
     )
   )
   project                  = var.project_id
@@ -160,13 +190,13 @@ resource "google_spanner_database_iam_member" "database" {
     (
       local.enable_instance_nn ?
       google_spanner_instance.instance_num_node[0].name :
-      google_spanner_instance.instance_processing_units[0].name
+      (try(var.instance_size.enable_autoscaling, false) ? google_spanner_instance.autoscaled[0].name : google_spanner_instance.instance_processing_units[0].name)
     )
   )
   project  = var.project_id
   database = element(split("|", each.key), 0)
-  role     = element(split("|", each.key), 2)
-  member   = element(split("|", each.key), 1)
+  role     = element(split("|", each.key), 1)
+  member   = element(split("|", each.key), 2)
 
   depends_on = [
     google_spanner_database.database

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,11 +18,11 @@ output "spanner_instance_id" {
   description = "Spanner Instance ID"
   value = (
     !var.create_instance ?
-    data.google_spanner_instance.instance[0].id :
+    data.google_spanner_instance.instance[0].name :
     (
       local.enable_instance_nn ?
-      google_spanner_instance.instance_num_node[0].id :
-      google_spanner_instance.instance_processing_units[0].id
+      google_spanner_instance.instance_num_node[0].name :
+      (try(var.instance_size.enable_autoscaling, false) ? google_spanner_instance.autoscaled[0].name : google_spanner_instance.instance_processing_units[0].name)
     )
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,19 +35,22 @@ variable "instance_config" {
   type        = string
 }
 
+
 variable "instance_size" {
   description = "The sizing configuration of Spanner Instance based on num of nodes OR instance processing units."
   type = object({
-    num_nodes        = optional(number)
-    processing_units = optional(number)
+    num_nodes          = optional(number)
+    processing_units   = optional(number)
+    enable_autoscaling = optional(bool, false)
   })
   validation {
     condition = !(
       try(var.instance_size.num_nodes, null) == null
       &&
       try(var.instance_size.processing_units, null) == null
+      && !try(var.instance_size.enable_autoscaling, false)
     )
-    error_message = "Either num_nodes OR processing_units information is supported."
+    error_message = "Either num_nodes OR processing_units OR autoscaling information is supported."
   }
 }
 
@@ -55,12 +58,6 @@ variable "create_instance" {
   description = "Switch to use create OR use existing Spanner Instance "
   type        = bool
   default     = true
-}
-
-variable "enable_autoscaling" {
-  description = "Enable autoscaling for the Spanner Instance"
-  type        = bool
-  default     = false
 }
 
 variable "instance_iam" {
@@ -82,7 +79,7 @@ variable "database_config" {
     ddl                      = optional(list(string), [])
     kms_key_name             = optional(string)
     deletion_protection      = bool
-    database_iam             = optional(list(string), [])
+    database_iam             = optional(map(list(string)), {})
     enable_backup            = optional(bool)
     backup_retention         = optional(string)
     create_db                = optional(bool)
@@ -92,7 +89,7 @@ variable "database_config" {
       version_retention_period = "3d"
       ddl                      = []
       deletion_protection      = false
-      database_iam             = []
+      database_iam             = {}
       enable_backup            = true
       backup_retention         = "86400s"
       create_db                = true
@@ -106,58 +103,49 @@ variable "cron_spec_text" {
   default     = "0 2 * * *" // Example: once a day at 2 AM UTC
 }
 
-variable "min_processing_units" {
-  description = "Minimum number of processing units for autoscaling."
-  type        = number
-  default     = 1000
+variable "autoscaling_limits" {
+  description = <<EOT
+  Minimum number of processing units for autoscaling.
+  Maximum number of processing units for autoscaling.
+  Minimum number of nodes for autoscaling.
+  Maximum number of nodes for autoscaling.
+  EOT
+  type = object({
+    min_processing_units = optional(number, 0)
+    max_processing_units = optional(number, 0)
+    min_nodes            = optional(number, 0)
+    max_nodes            = optional(number, 0)
+  })
+  nullable = true
 }
 
-variable "max_processing_units" {
-  description = "Maximum number of processing units for autoscaling."
-  type        = number
-  default     = 3000
+variable "autoscaling_targets" {
+  description = "Targets for autoscaling high priority CPU and storage utilization percentage for autoscaling."
+  type = object({
+    high_priority_cpu_utilization_percent = optional(number, 60)
+    storage_utilization_percent           = optional(number, 70)
+  })
+  nullable = true
 }
 
-variable "min_nodes" {
-  description = "Minimum number of nodes for autoscaling."
-  type        = number
-  default     = 1
-}
-
-variable "max_nodes" {
-  description = "Maximum number of nodes for autoscaling."
-  type        = number
-  default     = 3
-}
-
-variable "high_priority_cpu_utilization_percent" {
-  description = "Target high priority CPU utilization percentage for autoscaling."
-  type        = number
-  default     = 60
-}
-
-variable "storage_utilization_percent" {
-  description = "Target storage utilization percentage for autoscaling."
-  type        = number
-  default     = 70
-}
-
-variable "replica_location" {
-  description = "Location of the replica for asymmetric autoscaling."
-  type        = string
-  default     = "us-central1"
-}
-
-variable "override_min_nodes" {
-  description = "Minimum number of nodes for specific replica overrides."
-  type        = number
-  default     = 1
-}
-
-variable "override_max_nodes" {
-  description = "Maximum number of nodes for specific replica overrides."
-  type        = number
-  default     = 3
+variable "asymmetric_autoscaling_options" {
+  description = <<EOT
+    Location of the replica for asymmetric autoscaling.
+    Minimum number of nodes for specific replica overrides.
+    Maximum number of nodes for specific replica overrides.
+  EOT
+  type = object(
+    {
+      location = optional(string)
+      override_autoscaling_limits = optional(object(
+        {
+          min_nodes = optional(number)
+          max_nodes = optional(number)
+        }
+      ))
+    }
+  )
+  nullable = true
 }
 
 variable "edition" {


### PR DESCRIPTION
We were trying to use this module in a real scenario. Unfortunately the module does not work especially with autoscaling.

In addition passing the iam in as a string instead of just a map of {role: [member}, is quite the hassle, so I went ahead  and refactored that part as well.

Now users should be able to utilize autoscaling, while also only passing autoscaling parameters that they actually need.

As we only could test the two types of autoscaling, autoscaling limits was not tested for proper defaults in optional.


This is already deployed in production on our side